### PR TITLE
Restart the server when its event loop wedges; cut the spawn rate

### DIFF
--- a/server/50-tvweb.sh
+++ b/server/50-tvweb.sh
@@ -20,12 +20,18 @@ if [ -f /var/lib/tvweb/adblock_enabled ] && [ -f /var/lib/tvweb/adblock_hosts ];
 fi
 
 # Detach fully so upstart/webosbrew startup is never held up by this.
+# Prefer tvwebctl: it starts the watchdog alongside the server. The direct
+# line stays as a fallback for installs that predate that script.
 (
   sleep 20   # let the TV finish booting before adding load
   /usr/bin/pkill -9 -f tvweb.js 2>/dev/null || true
   sleep 1
-  setsid /usr/bin/node /var/lib/tvweb/tvweb.js \
-    > /var/lib/tvweb/tvweb.log 2>&1 &
+  if [ -x /var/lib/tvweb/tvwebctl ]; then
+    /var/lib/tvweb/tvwebctl start
+  else
+    setsid /usr/bin/node /var/lib/tvweb/tvweb.js \
+      > /var/lib/tvweb/tvweb.log 2>&1 &
+  fi
 ) &
 
 exit 0

--- a/server/assets/ui.html
+++ b/server/assets/ui.html
@@ -926,10 +926,11 @@ async function loadHdmi() {
   }
 }
 
-let hdmiTimer = null;
 function onHdmiToggle(el) {
-  clearInterval(hdmiTimer);
-  if (el.open) { loadHdmi(); hdmiTimer = setInterval(loadHdmi, 5000); }
+  /* Loaded on open, not polled. Each read is a luna-send fork on the TV, and
+     link state does not change while someone stares at the panel; reopening
+     it refreshes. */
+  if (el.open) loadHdmi();
 }
 
 (function wireHdmiPanel() {
@@ -954,10 +955,9 @@ async function loadProcesses() {
 }
 
 // Only poll while the panel is open; it costs a ps on the TV each time.
-let procTimer = null;
 function onProcToggle(el) {
-  clearInterval(procTimer);
-  if (el.open) { loadProcesses(); procTimer = setInterval(loadProcesses, 5000); }
+  /* Same as the HDMI panel: on open only. This one forks `ps`. */
+  if (el.open) loadProcesses();
 }
 
 (function wireProcPanel() {

--- a/server/tvweb.js
+++ b/server/tvweb.js
@@ -314,6 +314,31 @@ function luna(uri, payload, cb, appId) {
   });
 }
 
+/*
+ * Cache for luna reads whose answers do not change between dashboard ticks.
+ * Every luna() call is a fork+exec, and collectStats made ten of them per
+ * collection at a 2s tick - roughly five forks a second with the dashboard
+ * open. Node 0.12's spawn path can deadlock under that (see the watchdog note
+ * in tvwebctl), so set-and-forget settings are now read once per TTL.
+ *
+ * Any successful control clears the lot, so a setting the user just changed is
+ * never served from cache.
+ */
+var lunaCache = {};
+
+function lunaCached(uri, payload, ttlMs, cb) {
+  var key = uri + '|' + JSON.stringify(payload || {});
+  var hit = lunaCache[key];
+  if (hit && (Date.now() - hit.t < ttlMs)) return cb(hit.v, hit.raw);
+  luna(uri, payload, function (parsed, raw) {
+    // Only a real answer is worth pinning; a failed read should be retried.
+    if (parsed) lunaCache[key] = { t: Date.now(), v: parsed, raw: raw };
+    cb(parsed, raw);
+  });
+}
+
+function clearLunaCache() { lunaCache = {}; }
+
 function detectDeviceInfo(cb) {
   luna('com.webos.service.tv.systemproperty/getSystemProperties',
     { keys: ['modelName', 'firmwareVersion', 'boardType'] },
@@ -752,11 +777,11 @@ function collectStats(cb) {
   // Chained Luna queries: power -> sound -> soundSettings -> foregroundApp -> picture settings -> apps
   luna('com.webos.service.tvpower/power/getPowerState', {}, function (pw) {
     out.powerState = mapPowerState(pw && pw.state);
-  luna('com.webos.service.settings/getSystemSettings',
-       { category: 'time', keys: ['sleepTimer'] }, function (tm) {
+  lunaCached('com.webos.service.settings/getSystemSettings',
+       { category: 'time', keys: ['sleepTimer'] }, 30000, function (tm) {
     out.sleepTimer = (tm && tm.settings && tm.settings.sleepTimer) || 'off';
-  luna('com.webos.service.settings/getSystemSettings',
-       { category: 'option', keys: ['standByLight', 'logoLight', 'powerOnLight'] }, function (op) {
+  lunaCached('com.webos.service.settings/getSystemSettings',
+       { category: 'option', keys: ['standByLight', 'logoLight', 'powerOnLight'] }, 60000, function (op) {
     var os = (op && op.settings) || {};
     out.lights = {
       standby: os.standByLight === 'on',
@@ -765,14 +790,14 @@ function collectStats(cb) {
       hasLogo: hasLogoLight === true
     };
     out.gpuMhz = gpuClockMhz();
-  luna('com.palm.connectionmanager/getStatus', {}, function (cm) {
+  lunaCached('com.palm.connectionmanager/getStatus', {}, 60000, function (cm) {
     // Network name, so the Wi-Fi figures say which network they refer to.
     var w = cm && cm.wifi;
     out.ssid = (w && w.ssid) ? w.ssid : null;
-  luna('com.webos.service.tv.display/getDimmingStatus', {}, function (dim) {
+  lunaCached('com.webos.service.tv.display/getDimmingStatus', {}, 15000, function (dim) {
     // ABL / logo dimming activity. OLED only in practice.
     out.dimming = (dim && dim.status) || null;
-  luna('com.webos.service.tv.display/getLightSensorData', {}, function (ls) {
+  lunaCached('com.webos.service.tv.display/getLightSensorData', {}, 30000, function (ls) {
     /*
      * Ambient light sensor. Not every set has one: a model without it still
      * answers, reporting 65535 (0xFFFF) for every channel. Treat that as
@@ -789,14 +814,14 @@ function collectStats(cb) {
     out.backlight = (ls && typeof ls.backlightValue === 'number') ? ls.backlightValue : null;
   appStorage(function (st) {
     out.appStorage = st;
-  luna('com.webos.audio/getSoundOut', {}, function (sound) {
+  lunaCached('com.webos.audio/getSoundOut', {}, 10000, function (sound) {
     if (sound) {
       out.volume = sound.volume;
       out.muted = !!sound.muted;
       out.audio_output = sound.scenario || 'internal';
     }
-    luna('com.webos.service.settings/getSystemSettings',
-      { category: 'sound', keys: ['soundOutput', 'soundMode'] },
+    lunaCached('com.webos.service.settings/getSystemSettings',
+      { category: 'sound', keys: ['soundOutput', 'soundMode'] }, 15000,
       function (snd) {
         var rawSnd = (snd && snd.settings && snd.settings.soundOutput) ? snd.settings.soundOutput : (sound && sound.scenario ? sound.scenario : 'tv_speaker');
         out.sound = {
@@ -804,7 +829,7 @@ function collectStats(cb) {
           output_raw: rawSnd,
           mode: (snd && snd.settings && snd.settings.soundMode) || 'standard'
         };
-        luna('com.webos.applicationManager/getForegroundAppInfo', {}, function (app) {
+        lunaCached('com.webos.applicationManager/getForegroundAppInfo', {}, 4000, function (app) {
           if (app && app.appId) {
             var shortApp = String(app.appId).replace('com.webos.app.', '');
             out.app = shortApp;
@@ -812,9 +837,9 @@ function collectStats(cb) {
             out.display_title = (inputNameMap[shortApp] && inputNameMap[shortApp] !== shortApp) ?
               (inputNameMap[shortApp] + ' (' + shortApp.toUpperCase() + ')') : shortApp;
           }
-          luna('com.webos.service.settings/getSystemSettings',
+          lunaCached('com.webos.service.settings/getSystemSettings',
             { category: 'picture', keys: ['backlight', 'pictureMode', 'energySaving', 'screenShift', 'logoLuminanceAdjust'] },
-            function (pic) {
+            10000, function (pic) {
               if (pic && pic.settings) {
                 var rawDr = (pic.dimension && pic.dimension.dynamicRange) ? pic.dimension.dynamicRange : 'sdr';
                 out.picture = {
@@ -1181,7 +1206,7 @@ function doControl(action, value, cb) {
 
   var origCb = cb;
   cb = function (r) {
-    if (r && r.ok) lastStats = null;
+    if (r && r.ok) { lastStats = null; clearLunaCache(); }
     origCb(r);
   };
 
@@ -3454,6 +3479,28 @@ function setupHomeAssistant() {
 
   mqttClient.connect();
 }
+
+/*
+ * Liveness marker for the watchdog in tvwebctl.
+ *
+ * A wedged server keeps its port open and its process alive, so "is it
+ * listening" proves nothing: on 2026-09-09 the loop froze inside libuv's
+ * spawn path - a forked child deadlocked on a futex before reaching exec, so
+ * the parent blocked forever reading the 4-byte exec-error pipe - and the
+ * dashboard, MQTT and everything else stopped while the process looked fine.
+ * A timer that stops firing is the signal that catches it. /var/run is tmpfs,
+ * so this costs no flash writes.
+ */
+var BEAT_FILE = '/var/run/tvweb.beat';
+
+/* Seconds, not milliseconds: the watchdog is busybox ash, whose arithmetic is
+   32-bit, and a 13-digit millisecond stamp overflows it into nonsense. */
+function heartbeat() {
+  fs.writeFile(BEAT_FILE, String(Math.floor(Date.now() / 1000)), function () {});
+}
+
+heartbeat();
+setInterval(heartbeat, 20000);
 
 detectDeviceInfo(function() {
   setupHomeAssistant();

--- a/server/tvwebctl
+++ b/server/tvwebctl
@@ -1,29 +1,42 @@
 #!/bin/sh
-# tvwebctl - start/stop/restart the tvweb server on the TV.
+# tvwebctl - start/stop/restart the tvweb server on the TV, and the watchdog
+# that restarts it if its event loop stops turning.
 #
 # Exists as a script rather than an inline ssh command on purpose: `pkill -f
 # tvweb.js` typed into an ssh command matches the remote shell running that
 # very command (its argv contains the path), so the shell kills itself before
 # starting anything. Inside a script, the shell's argv is just this file.
 #
-# Usage: tvwebctl {start|stop|restart|status}
+# Usage: tvwebctl {start|stop|restart|status|watch}
 
 APP=/var/lib/tvweb/tvweb.js
 LOG=/var/lib/tvweb/tvweb.log
 PIDFILE=/var/run/tvweb.pid
+WATCHPID=/var/run/tvwebwatch.pid
+BEAT=/var/run/tvweb.beat
+# Restarts are recorded here rather than in $LOG, which start_app truncates -
+# a watchdog whose evidence is erased by its own restart is no use.
+RESTARTS=/var/lib/tvweb/tvweb.restarts
 NODE=/usr/bin/node
+SELF=$(readlink -f "$0" 2>/dev/null || echo /var/lib/tvweb/tvwebctl)
 
-stop() {
+# How long the heartbeat may go unwritten before the server is considered
+# wedged. The server writes it every 20s, so this is five missed beats - long
+# enough that a busy TV delaying a timer is never mistaken for a hang.
+STALE=90
+CHECK=30
+
+stop_app() {
   start-stop-daemon -K -q -p "$PIDFILE" 2>/dev/null
   # Catch instances started before this script existed.
   for p in $(ps -eo pid,args 2>/dev/null | grep "$APP" | grep -v grep | awk '{print $1}'); do
     [ "$p" = "$$" ] && continue
     kill -9 "$p" 2>/dev/null
   done
-  rm -f "$PIDFILE"
+  rm -f "$PIDFILE" "$BEAT"
 }
 
-start() {
+start_app() {
   [ -x "$NODE" ] || { echo "node not found at $NODE"; exit 1; }
   [ -f "$APP" ]  || { echo "not installed: $APP"; exit 1; }
   chmod 600 /var/lib/tvweb/config.json 2>/dev/null
@@ -32,15 +45,61 @@ start() {
   start-stop-daemon -S -b -m -p "$PIDFILE" -x /bin/sh -- -c "exec $NODE $APP >$LOG 2>&1"
 }
 
+stop_watch() {
+  start-stop-daemon -K -q -p "$WATCHPID" 2>/dev/null
+  rm -f "$WATCHPID"
+}
+
+start_watch() {
+  start-stop-daemon -S -b -m -p "$WATCHPID" -x /bin/sh -- -c "exec $SELF watch"
+}
+
+# The watchdog loop. Runs as its own detached process; restarts only the app,
+# never itself, so a restart cannot orphan the watchdog.
+#
+# A wedged server still holds its port open and still looks alive to `kill -0`,
+# so liveness is judged by the heartbeat file the server rewrites every 20s.
+# An absent heartbeat is deliberately NOT a fault: a server predating the
+# heartbeat, or one still starting up, would otherwise be restarted forever.
+watch_loop() {
+  while true; do
+    sleep "$CHECK"
+    [ -f "$PIDFILE" ] || continue                     # stopped on purpose
+    if ! kill -0 "$(cat "$PIDFILE" 2>/dev/null)" 2>/dev/null; then
+      echo "$(date): process gone - starting" >> "$RESTARTS"
+      start_app
+      continue
+    fi
+    beat=$(cat "$BEAT" 2>/dev/null)
+    case "$beat" in ''|*[!0-9]*) continue ;; esac     # no usable heartbeat yet
+    age=$(( $(date +%s) - beat ))
+    if [ "$age" -gt "$STALE" ]; then
+      echo "$(date): heartbeat ${age}s old - event loop wedged, restarting" >> "$RESTARTS"
+      stop_app; sleep 1; start_app
+    fi
+  done
+}
+
 case "$1" in
-  start)   start ;;
-  stop)    stop ;;
-  restart) stop; sleep 1; start ;;
+  start)   start_app; start_watch ;;
+  stop)    stop_watch; stop_app ;;
+  restart) stop_watch; stop_app; sleep 1; start_app; start_watch ;;
+  watch)   watch_loop ;;
   status)
     if [ -f "$PIDFILE" ] && kill -0 "$(cat $PIDFILE)" 2>/dev/null; then
       echo "running (pid $(cat $PIDFILE))"
     else
       echo "not running"
-    fi ;;
-  *) echo "usage: $0 {start|stop|restart|status}"; exit 2 ;;
+    fi
+    if [ -f "$WATCHPID" ] && kill -0 "$(cat $WATCHPID)" 2>/dev/null; then
+      beat=$(cat "$BEAT" 2>/dev/null)
+      case "$beat" in
+        ''|*[!0-9]*) echo "watchdog running (pid $(cat $WATCHPID)), no heartbeat yet" ;;
+        *) echo "watchdog running (pid $(cat $WATCHPID)), heartbeat $(( $(date +%s) - beat ))s old" ;;
+      esac
+    else
+      echo "watchdog not running"
+    fi
+    [ -s "$RESTARTS" ] && echo "last restart: $(tail -1 "$RESTARTS")" ;;
+  *) echo "usage: $0 {start|stop|restart|status|watch}"; exit 2 ;;
 esac


### PR DESCRIPTION
The dashboard and MQTT both went dead on 2026-09-09 while the server looked
healthy — process alive, port 8080 listening, nothing logged.

It had frozen inside libuv's spawn path. A forked child deadlocked on a futex
before reaching `exec`, so the parent blocked forever on the 4-byte exec-error
pipe libuv uses to report exec failures. Diagnosis at the time:

```
main thread  wchan=pipe_wait   read(fd 26, ..., 4)
fd 26 -> pipe:[82661]          (read end)
child 9259   threads=1  wchan=futex_wait_queue_me  never exec'd
             fd 27 -> pipe:[82661]  (write end, so no EOF)
```

Collateral: three HTTP connections ESTABLISHED with 451/341/341 bytes unread,
the broker's disconnect unnoticed in CLOSE_WAIT, a zombie `ps` unreaped.

## Restart it when it stops

Neither liveness of the process nor an open port distinguishes this state from
a working server, so the server writes a heartbeat to `/var/run` (tmpfs, no
flash wear) and `tvwebctl` runs a watchdog that restarts it when the heartbeat
goes stale. An absent heartbeat is deliberately not a fault, so a server
predating this cannot be restarted in a loop. Restarts are recorded in
`tvweb.restarts`, not the log that `start_app` truncates. The boot hook goes
through `tvwebctl` so the watchdog starts at boot.

## Fork less

`collectStats` made ten `luna-send` spawns per collection, and the 1.5s stats
cache never survived the 2s dashboard tick. Two disclosure panels polled on 5s
timers on top, one forking `ps`. Reads are now cached per-TTL by how fast the
value actually moves, and those panels load on open. Any successful control
clears the cache, so a just-changed setting is never served stale.

This narrows the window rather than closing it: the race is against libuv's
threadpool threads, not against other spawns, so the watchdog is the actual
safety net.

## Verified on the B8

- Froze the server with SIGSTOP — the exact signature, alive with the port
  open. Watchdog restarted it 115s later; dashboard returned 200 and the
  reason survived in the record.
- Spawns over 30s with a 2s poll: 162 before, 34 after.
- Volume changed through `/api/control` reads back immediately, so cache
  invalidation holds.

Fixed along the way: the heartbeat was written in milliseconds, which
overflows busybox's 32-bit shell arithmetic — the watchdog would have
restarted the server every 30 seconds. It is written in seconds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)