### PR TITLE
Picture modes, split control groups, and an honest screen saver

### DIFF
--- a/server/assets/ui.html
+++ b/server/assets/ui.html
@@ -75,7 +75,9 @@ body{
 /* ---- masthead ---- */
 header{display:flex;justify-content:space-between;align-items:baseline;gap:24px;flex-wrap:wrap}
 .mark{font-family:'Outfit';font-weight:300;font-size:clamp(19px,2.4vw,26px);color:var(--w100);letter-spacing:.01em}
-.mark span{color:var(--w50)}
+/* The model number identifies the set; the name is what you are looking at.
+   Setting them at one size let the longer of the two dominate. */
+.mark span{color:var(--w50);font-size:.68em;letter-spacing:.02em;margin-left:2px}
 .src{text-align:right}
 .src .t{font-family:'Outfit';font-weight:300;font-size:clamp(15px,1.8vw,19px);color:var(--w80)}
 .src .m{font-size:13px;color:var(--w50);letter-spacing:.02em}
@@ -354,7 +356,7 @@ footer{margin-top:38px;font-size:12px;letter-spacing:.10em;text-transform:upperc
       <div class="btns">
         <button id="btn-screenoff" onclick="c('screenOff')">Screen off</button>
         <button id="btn-screenon" onclick="c('screenOn')">Screen on</button>
-        <button onclick="c('screensaver')">Screensaver</button>
+        <button id="btn_ss" onclick="c('screensaver')">Screensaver</button>
       </div>
     </div>
 
@@ -380,9 +382,9 @@ footer{margin-top:38px;font-size:12px;letter-spacing:.10em;text-transform:upperc
     </div>
 
     <details class="disc" id="disc-timers">
-      <summary>Timer &amp; lights <span class="cur" id="tl-cur"></span></summary>
+      <summary>Sleep timer <span class="cur" id="tl-cur"></span></summary>
 
-      <div class="set"><div class="lbl">Sleep timer</div>
+      <div class="set">
         <div class="btns" id="sleepbtns">
           <button id="sl_off" onclick="c('sleepTimer','off')">Off</button>
           <button id="sl_10"  onclick="c('sleepTimer','10')">10 min</button>
@@ -392,8 +394,11 @@ footer{margin-top:38px;font-size:12px;letter-spacing:.10em;text-transform:upperc
           <button id="sl_120" onclick="c('sleepTimer','120')">120 min</button>
         </div>
       </div>
+    </details>
 
-      <div class="set"><div class="lbl">Front lights</div>
+    <details class="disc" id="disc-lights">
+      <summary>Front lights <span class="cur" id="lt-cur"></span></summary>
+      <div class="set">
         <div class="btns">
           <button id="lt_standby" onclick="toggleLight('standbyLight')">Standby LED</button>
           <button id="lt_logo" onclick="toggleLight('logoLight')" hidden>Logo light</button>
@@ -402,15 +407,20 @@ footer{margin-top:38px;font-size:12px;letter-spacing:.10em;text-transform:upperc
     </details>
 
     <details class="disc" id="disc-display">
-      <summary>Display &amp; sound <span class="cur" id="ds-cur"></span></summary>
+      <summary>Picture <span class="cur" id="ds-cur"></span></summary>
 
-      <div class="set"><div class="lbl">Picture mode &middot; <span id="picmode-lbl" class="num">&mdash;</span></div>
+      <div class="set"><div class="lbl">Mode &middot; <span id="picmode-lbl" class="num">&mdash;</span></div>
         <!-- Built from what the TV says it will accept: the settable modes
              change with the dynamic range of what is playing. -->
         <div class="btns" id="picmodes"></div>
       </div>
 
-      <div class="set"><div class="lbl">Sound output &middot; <span id="soundout-lbl" class="num">&mdash;</span></div>
+    </details>
+
+    <details class="disc" id="disc-sound">
+      <summary>Sound <span class="cur" id="snd-cur"></span></summary>
+
+      <div class="set"><div class="lbl">Output &middot; <span id="soundout-lbl" class="num">&mdash;</span></div>
         <div class="btns" id="soundouts">
           <button id="so_tv_speaker" onclick="c('soundOutput','tv_speaker')">TV Speaker</button>
           <button id="so_external_arc" onclick="c('soundOutput','external_arc')">HDMI ARC</button>
@@ -718,15 +728,16 @@ async function tick() {
         q('lt_logo').classList.toggle('on', !!lights.logo);
       }
       if (q('tl-cur')) {
-        const bits = [st === 'off' ? 'No sleep timer' : `Sleep in ${st} min`];
+        q('tl-cur').textContent = st === 'off' ? 'Off' : `${st} min`;
+      }
+      if (q('lt-cur')) {
         const lit = [lights.standby && 'standby LED',
                      lights.hasLogo && lights.logo && 'logo'].filter(Boolean);
-        bits.push(lit.length ? lit.join(' + ') + ' on' : 'lights off');
-        q('tl-cur').textContent = bits.join('  ·  ');
+        q('lt-cur').textContent = lit.length ? lit.join(' + ') + ' on' : 'Off';
       }
 
-      q('ds-cur').textContent = [pic.mode, audioLabel(d.audio_output)]
-        .filter(Boolean).join('  ·  ');
+      q('ds-cur').textContent = pic.mode || '';
+      if (q('snd-cur')) q('snd-cur').textContent = audioLabel(d.audio_output) || '';
     }
     const dr = pic.dynamicRange || '';
     const drCol = /dolby/i.test(dr) ? 'var(--purple-t)' : /hdr/i.test(dr) ? 'var(--cand)' : 'var(--w60)';
@@ -857,6 +868,15 @@ async function tick() {
           b.classList.toggle('on', b.id === 'app_' + d.app.replace(/[^a-zA-Z0-9_-]/g, '_') || b.id === 'app_com_webos_app_' + d.app);
         }
       }
+    }
+
+    /* The screen saver is drawn by whatever app registered for it, and an
+       input registers nothing - so it cannot run over HDMI or Live TV. Show
+       that rather than leaving a button that does nothing when pressed. */
+    if (q('btn_ss')) {
+      const onInput = /^hdmi[1-4]$/.test(d.app || '') || d.app === 'livetv';
+      q('btn_ss').disabled = onInput;
+      q('btn_ss').title = onInput ? 'Available from an app, not from ' + d.app : '';
     }
 
     if (d.picture) {

--- a/server/assets/ui.html
+++ b/server/assets/ui.html
@@ -40,8 +40,10 @@
      4.5:1 floor applies to anything that is not large. The steps below w50 are
      for rules, borders and fills. */
   /* Accents, taken from the Velo light-scene swatches (Nanoleaf/Hue/LIFX).
-     Used to carry meaning only - thermal state, headroom, signal format -
-     never as decoration. The chrome stays monochrome. */
+     Colour is only ever applied to something that CHANGES it: level, thermal
+     state, signal format, a privacy pill. If a thing would be the same colour
+     for the life of the install, it is not colour, it is decoration - and it
+     goes monochrome. The chrome stays monochrome. */
   --cool:#D4E3FF; --warm:#FFDEA1; --cand:#FFB04F;
   --red:#FF3030;  --blue:#3061FF; --green:#30DE61; --purple:#8F30FF;
   /* Lighter violet for TEXT: #8F30FF is only 4.03:1 on black, under the
@@ -120,7 +122,7 @@ header{display:flex;justify-content:space-between;align-items:baseline;gap:24px;
 /* ---- panel block: the second thing worth looking at ---- */
 
 .n{font-family:'Outfit';font-weight:200;font-size:clamp(52px,9vw,90px);color:var(--w100);line-height:.9;letter-spacing:-.02em}
-.n em{font-style:normal;color:var(--purple-t);font-size:.26em;letter-spacing:.14em;margin-left:12px;font-family:'Manrope';font-weight:500}
+.n em{font-style:normal;color:var(--w50);font-size:.26em;letter-spacing:.14em;margin-left:12px;font-family:'Manrope';font-weight:500}
 .cols{display:grid;grid-template-columns:repeat(auto-fit,minmax(148px,1fr));gap:26px;margin-top:26px}
 .cols .v{font-family:'Outfit';font-weight:300;font-size:24px;color:var(--w100);margin-top:6px}
 
@@ -519,10 +521,14 @@ const ROWS = [
   { k: 'cpu',   label: 'Processor',  warn: 85 },
   { k: 'mem',   label: 'Memory',     warn: 90 },
   { k: 'swap',  label: 'Swap',       warn: 70 },
-  { k: 'net',   label: 'Network',    warn: 101, tint: 'var(--blue)' },
-  { k: 'draw',  label: 'Current',    warn: 101, tint: 'var(--warm)' }
+  /* Throughput and draw have no threshold to cross - warn: 101 was the tell.
+     A level hue on them would be a lie, and the fixed blue and amber they used
+     to carry read as level anyway, sitting in a column where every other bar
+     meant exactly that. Their domain shows on the unit instead. */
+  { k: 'net',   label: 'Network',    warn: 101, flat: true },
+  { k: 'draw',  label: 'Current',    warn: 101, flat: true }
 ];
-const TINT = Object.fromEntries(ROWS.map(r => [r.k, r.tint || null]));
+const FLAT = Object.fromEntries(ROWS.map(r => [r.k, !!r.flat]));
 
 /*
  * The hero stays white through the whole normal operating band, and only takes
@@ -668,7 +674,7 @@ function row(k, val, pct, sub, warn) {
   q('val-' + k).innerHTML = val;
   const bar = q('bar-' + k);
   bar.style.width = Math.max(0, Math.min(100, pct)) + '%';
-  bar.style.background = TINT[k] || headroom(pct, warn);
+  bar.style.background = FLAT[k] ? 'var(--w60)' : headroom(pct, warn);
   q('sub-' + k).textContent = sub || '';
   q('row-' + k).classList.toggle('hi', pct >= warn);
 }

--- a/server/assets/ui.html
+++ b/server/assets/ui.html
@@ -405,13 +405,9 @@ footer{margin-top:38px;font-size:12px;letter-spacing:.10em;text-transform:upperc
       <summary>Display &amp; sound <span class="cur" id="ds-cur"></span></summary>
 
       <div class="set"><div class="lbl">Picture mode &middot; <span id="picmode-lbl" class="num">&mdash;</span></div>
-        <div class="btns" id="picmodes">
-          <button id="pm_expert1" onclick="c('pictureMode','expert1')">ISF Bright</button>
-          <button id="pm_expert2" onclick="c('pictureMode','expert2')">ISF Dark</button>
-          <button id="pm_cinema" onclick="c('pictureMode','cinema')">Cinema</button>
-          <button id="pm_game" onclick="c('pictureMode','game')">Game</button>
-          <button id="pm_standard" onclick="c('pictureMode','standard')">Standard</button>
-        </div>
+        <!-- Built from what the TV says it will accept: the settable modes
+             change with the dynamic range of what is playing. -->
+        <div class="btns" id="picmodes"></div>
       </div>
 
       <div class="set"><div class="lbl">Sound output &middot; <span id="soundout-lbl" class="num">&mdash;</span></div>
@@ -865,10 +861,22 @@ async function tick() {
 
     if (d.picture) {
       if (q('picmode-lbl')) q('picmode-lbl').textContent = (d.picture.mode || d.picture.mode_raw || '').toUpperCase();
-      const pmBtns = q('picmodes') ? q('picmodes').querySelectorAll('button') : [];
-      for (let b of pmBtns) {
-        const m = b.id.replace('pm_', '');
-        b.classList.toggle('on', d.picture.mode_raw === m || (m === 'expert1' && d.picture.mode_raw.indexOf('expert1') !== -1) || (m === 'expert2' && d.picture.mode_raw.indexOf('expert2') !== -1));
+      /* Rebuild only when the set actually changes - it changes when the source
+         does, and rewriting the buttons on every tick would kill the :active
+         state mid-press. */
+      const modes = d.picture.modes || [];
+      const sig = modes.map(m => m.value).join(',');
+      const box = q('picmodes');
+      if (box && box.dataset.sig !== sig) {
+        box.dataset.sig = sig;
+        box.innerHTML = modes.map(m =>
+          `<button id="pm_${m.value}" onclick="c('pictureMode','${m.value}')">${esc(m.label)}</button>`
+        ).join('');
+      }
+      if (box) {
+        for (let b of box.querySelectorAll('button')) {
+          b.classList.toggle('on', b.id.replace('pm_', '') === d.picture.mode_raw);
+        }
       }
     }
 

--- a/server/assets/ui.html
+++ b/server/assets/ui.html
@@ -311,7 +311,7 @@ footer{margin-top:38px;font-size:12px;letter-spacing:.10em;text-transform:upperc
 
     <div class="grp-sec" id="panelblock" hidden>
       <div class="grp">Display panel</div>
-      <div class="lbl">Lifespan</div>
+      <div class="lbl">Total power on hours</div>
       <div class="n num" style="margin-top:10px"><span id="ph">&mdash;</span><em>hours</em></div>
       <div class="cols">
         <div><div class="lbl">Compensation in</div><div class="v num" id="comp">&mdash;</div></div>

--- a/server/assets/ui.html
+++ b/server/assets/ui.html
@@ -396,16 +396,6 @@ footer{margin-top:38px;font-size:12px;letter-spacing:.10em;text-transform:upperc
       </div>
     </details>
 
-    <details class="disc" id="disc-lights">
-      <summary>Front lights <span class="cur" id="lt-cur"></span></summary>
-      <div class="set">
-        <div class="btns">
-          <button id="lt_standby" onclick="toggleLight('standbyLight')">Standby LED</button>
-          <button id="lt_logo" onclick="toggleLight('logoLight')" hidden>Logo light</button>
-        </div>
-      </div>
-    </details>
-
     <details class="disc" id="disc-display">
       <summary>Picture <span class="cur" id="ds-cur"></span></summary>
 
@@ -437,6 +427,13 @@ footer{margin-top:38px;font-size:12px;letter-spacing:.10em;text-transform:upperc
         <div class="app-grid" id="apps"></div>
       </div>
     </details>
+
+    <div class="set"><div class="lbl">Front lights</div>
+      <div class="btns">
+        <button id="lt_standby" onclick="toggleLight('standbyLight')">Standby LED</button>
+        <button id="lt_logo" onclick="toggleLight('logoLight')" hidden>Logo light</button>
+      </div>
+    </div>
 
     <div class="set"><div class="lbl">Privacy &amp; data collection</div>
       <div class="btns"><button id="privtoggle" onclick="togglePrivacy()">Show privacy panel</button></div>
@@ -729,11 +726,6 @@ async function tick() {
       }
       if (q('tl-cur')) {
         q('tl-cur').textContent = st === 'off' ? 'Off' : `${st} min`;
-      }
-      if (q('lt-cur')) {
-        const lit = [lights.standby && 'standby LED',
-                     lights.hasLogo && lights.logo && 'logo'].filter(Boolean);
-        q('lt-cur').textContent = lit.length ? lit.join(' + ') + ' on' : 'Off';
       }
 
       q('ds-cur').textContent = pic.mode || '';

--- a/server/tvweb.js
+++ b/server/tvweb.js
@@ -257,6 +257,8 @@ function getVideoSignal() {
 }
 
 var PIC_MODE_MAP = {
+  dolbyHdrVivid: 'Dolby Vision Vivid',
+  dolbyHdrCinemaBright: 'Dolby Vision Cinema Bright',
   dolbyHdrCinema: 'Dolby Vision Cinema',
   dolbyHdrCinemaHome: 'Dolby Vision Cinema Home',
   dolbyHdrStandard: 'Dolby Vision Standard',
@@ -274,6 +276,35 @@ var PIC_MODE_MAP = {
   sports: 'Sports',
   technicolorHdr: 'Technicolor HDR'
 };
+
+/*
+ * Which picture modes the set will accept right now.
+ *
+ * They depend on the dynamic range of what is playing: under Dolby Vision the
+ * only settable modes are the dolbyHdr* ones, and setting an SDR mode is
+ * refused with "There is No matched extended item: pictureMode". A fixed list
+ * therefore offers buttons that cannot work - which is what the dashboard used
+ * to do, showing SDR modes against Dolby Vision content.
+ *
+ * getSystemSettingValues marks the currently selectable ones visible:true, and
+ * that set changes with the source, so it is read rather than assumed.
+ */
+var lastPicModes = [];
+
+function pictureModes(cb) {
+  lunaCached('com.webos.service.settings/getSystemSettingValues',
+    { category: 'picture', key: 'pictureMode' }, 10000, function (res) {
+      var arr = (res && res.values && res.values.arrayExt) || [];
+      var out = [];
+      for (var i = 0; i < arr.length; i++) {
+        if (arr[i].visible === true && arr[i].active !== false) {
+          out.push({ value: arr[i].value, label: formatPicMode(arr[i].value) });
+        }
+      }
+      if (out.length) lastPicModes = out;
+      cb(out);
+    });
+}
 
 function formatPicMode(mode) {
   if (!mode) return 'Standard';
@@ -867,9 +898,12 @@ function collectStats(cb) {
                   backlight: num(pic.settings.backlight, 50),
                   energySaving: pic.settings.energySaving || 'off',
                   screenShift: pic.settings.screenShift || 'off',
-                  logoLuminanceAdjust: pic.settings.logoLuminanceAdjust || 'off'
+                  logoLuminanceAdjust: pic.settings.logoLuminanceAdjust || 'off',
+                  modes: []
                 };
               }
+              pictureModes(function (modes) {
+              if (out.picture) out.picture.modes = modes;
               refreshInstalledApps(function (apps) {
                 out.apps = apps || [];
                 out.privacy = {
@@ -895,6 +929,7 @@ function collectStats(cb) {
                     flushStats(out);
                   });
                 });
+              });
               });
             }
           );
@@ -3125,7 +3160,12 @@ function setupHomeAssistant() {
           command_topic: pfx + '/command/picture_mode',
           state_topic: telemetryTopic,
           value_template: '{{ value_json.picture.mode_raw if value_json.picture else "standard" }}',
-          options: ['expert1', 'expert2', 'cinema', 'game', 'standard', 'eco', 'sports'],
+          /* The settable modes depend on the dynamic range of what is playing,
+             so this is whatever the TV last said it would accept. Discovery is
+             republished when that set changes - see publishTelemetry. */
+          options: lastPicModes.length
+            ? lastPicModes.map(function (m) { return m.value; })
+            : ['expert1', 'expert2', 'cinema', 'game', 'standard', 'eco', 'sports'],
           icon: 'mdi:image-filter-black-white'
         }
       },
@@ -3421,6 +3461,8 @@ function setupHomeAssistant() {
     console.log('mqtt: published ' + entities.length + ' Home Assistant discovery entities');
   }
 
+  var lastPicSig = '';
+
   function publishTelemetry() {
     if (!mqttClient.connected) return;
     mqttClient.publish(statusTopic, 'online', true);
@@ -3436,6 +3478,21 @@ function setupHomeAssistant() {
        */
       if (s.powerState && typeof s.powerState.screenOn === 'boolean') {
         mqttClient.publish(stateScreenTopic, s.powerState.screenOn ? 'ON' : 'OFF', true);
+      }
+      /*
+       * The picture modes a set will accept change with the source's dynamic
+       * range, and a select whose options cannot be applied is worse than no
+       * select - Home Assistant would offer SDR modes against Dolby Vision
+       * content and every one of them would be refused. The options live in
+       * the discovery payload, so a changed set means republishing it.
+       */
+      var sig = ((s.picture && s.picture.modes) || []).map(function (m) {
+        return m.value;
+      }).join(',');
+      if (sig && sig !== lastPicSig) {
+        lastPicSig = sig;
+        console.log('mqtt: picture modes changed (' + sig + ') - republishing discovery');
+        publishDiscovery();
       }
     });
   }

--- a/server/tvweb.js
+++ b/server/tvweb.js
@@ -1417,8 +1417,23 @@ function doControl(action, value, cb) {
                   function (r) { lastStats = null; cb({ ok: !!(r && r.returnValue) }); });
 
     case 'screensaver':
-      return luna('com.webos.service.tvpower/power/turnOnScreenSaver', {},
-                  function (r) { cb({ ok: !!(r && r.returnValue) }); });
+      /*
+       * turnOnScreenSaver does not draw anything itself. tvpower asks whatever
+       * has registered a screen saver request to show one - see its
+       * registerScreenSaverRequest / responseScreenSaverRequest pair - and
+       * returns true whether or not anything answers. An HDMI input or Live TV
+       * registers nothing, because the screen saver exists to protect the panel
+       * from a static image, not to interrupt video. So on those sources the
+       * call reports success and nothing happens; say so instead.
+       */
+      return luna('com.webos.applicationManager/getForegroundAppInfo', {}, function (fg) {
+        var fgId = (fg && fg.appId) ? String(fg.appId).replace('com.webos.app.', '') : '';
+        if (/^hdmi[1-4]$/.test(fgId) || fgId === 'livetv') {
+          return cb({ ok: false, error: 'the screen saver is only available from an app, not from ' + fgId });
+        }
+        luna('com.webos.service.tvpower/power/turnOnScreenSaver', {},
+             function (r) { cb({ ok: !!(r && r.returnValue) }); });
+      });
 
     case 'toast':
       /* Both the payload's sourceId and luna-send's -a have to name an app the


### PR DESCRIPTION
Three reported problems and two follow-ups.

## Picture modes were the wrong set entirely

The dashboard offered five hardcoded SDR modes. Which modes a set accepts depends
on the dynamic range of what is playing — with Dolby Vision on screen the TV takes
only the `dolbyHdr*` modes and refuses the rest:

```
setSystemSettings pictureMode=cinema
  -> returnValue: false, "There is No matched extended item: pictureMode"
setSystemSettings pictureMode=dolbyHdrStandard
  -> returnValue: true
```

So every button on offer was inert, and the mode actually in use — Dolby Vision
Cinema — was not among them. `getSystemSettingValues` marks the currently
selectable modes `visible: true`, and that set changes with the source, so it is
read from the TV rather than assumed. The Home Assistant select carried the same
fixed list; its options live in the discovery payload, so discovery is
republished when the set changes.

## The screen saver could never work where it was offered

`turnOnScreenSaver` returned `true` and nothing appeared. It does not draw a
screen saver itself: tvpower asks whatever has registered a request — see its
`registerScreenSaverRequest` / `responseScreenSaverRequest` pair — and returns
true whether or not anything answers. An input registers nothing, because the
feature exists to protect the panel from a static image, not to interrupt video.
It runs from an app; over HDMI or Live TV the call was always going to succeed
and do nothing.

The button is disabled on those sources, and the control refuses with a reason
instead of claiming success.

## Paired groups split

Timer & lights and Display & sound each bundled two unrelated settings behind
one disclosure, so changing one meant unfolding the other and each summary had
to describe two states at once. Four groups now — Sleep timer, Front lights,
Picture, Sound — each summarising itself. It also closes part of the gap between
the columns:

| | metrics | controls | dead space |
| :--- | ---: | ---: | ---: |
| before | 1786px | 948px | 838px |
| after | 1786px | 1078px | 708px |

## Masthead

The name and the model number were set at the same size, so the longer of the
two dominated by length. The model is now subordinate to the name.

## Colour only where the colour changes

The Network and Current bars carried a fixed blue and amber in a column where
every other bar's colour meant level, so a permanently amber bar read as a
permanent warning. Neither has a threshold to cross — their `warn: 101` was
admitting as much. Both are neutral now. The unit under the panel lifespan was
purple permanently, leaving purple to mean two unrelated things on one screen; it
is monochrome, and purple means Dolby Vision alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)