### PR TITLE
Handle 0x-prefixed eMMC registers and fix telnet deploy on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ versions and panel types.
 | OLED55C1PUB | 6.x (6.3+) | 03.53.45 | OLED | SSH install and MQTT bridge confirmed |
 | 55UH6030-UC | 3.4.3 | &mdash; | LCD | |
 | OLED55G42LW | 24 | 33.31.68 | OLED | Rooted with slopbro, not the Homebrew Channel |
+| OLED42C24LA | 9.2.2 (22+) | 23.25.55 | OLED | Rooted with jsbro-autoroot |
 | OLED65B7V-Z | 3.9.3 | 06.10.65 | OLED | No SoC temperature or eMMC wear readings |
 
 **If you run it on anything else, please open an issue whether it's working or not**

--- a/server/assets/ui.html
+++ b/server/assets/ui.html
@@ -304,7 +304,7 @@ footer{margin-top:38px;font-size:12px;letter-spacing:.10em;text-transform:upperc
       <div class="grp">System</div>
       <section class="readouts" id="readouts"></section>
       <div class="cols" style="margin-top:20px">
-        <div><div class="lbl">GPU clock</div><div class="v num" id="gpuclk">&mdash;</div></div>
+        <div id="gpuclk-cell" hidden><div class="lbl">GPU clock</div><div class="v num" id="gpuclk">&mdash;</div></div>
         <div id="ssid-cell" hidden><div class="lbl">Network</div><div class="v" id="ssid">&mdash;</div><div class="sub">Connected Wi-Fi</div></div>
       </div>
     </div>
@@ -801,7 +801,8 @@ async function tick() {
     q('rstate').textContent = o.refresher_status || '—';
     // GPU clock, panel dimming, app storage and the ambient sensor. Each is
     // hidden when the set does not report it rather than showing a dash.
-    q('gpuclk').textContent = d.gpuMhz ? d.gpuMhz + ' MHz' : '—';
+    q('gpuclk-cell').hidden = !d.gpuMhz;
+    if (d.gpuMhz) q('gpuclk').textContent = d.gpuMhz + ' MHz';
     q('ssid-cell').hidden = !d.ssid;      // wired sets report none
     if (d.ssid) q('ssid').textContent = d.ssid;
     const dim = d.dimming;

--- a/server/deploy.sh
+++ b/server/deploy.sh
@@ -40,7 +40,7 @@ use_ssh() {
 
 tvsh() {   # run stdin on the TV over the homebrew root telnet
   { printf '\n'; sleep 1; cat; printf '\nexit\n'; sleep "${W:-8}"; } \
-    | nc -w $(( ${W:-8} + 5 )) "$TV" 23 2>/dev/null | tr -d '\r'
+    | nc -w $(( ${W:-8} + 5 )) "$TV" 23 2>/dev/null | LC_ALL=C tr -d '\r'
 }
 
 start_http() {

--- a/server/tvweb.js
+++ b/server/tvweb.js
@@ -176,7 +176,8 @@ function emmcInfo() {
    * wear counter could not be read is the same mistake as rendering 0 C for a
    * missing thermal sensor: it states as fact something never measured.
    */
-  var eol = (eolRaw && EOL_MAP[eolRaw.trim()]) || 'unknown';   // 0x00 is "not defined", not Normal
+  var eolKey = eolRaw ? eolRaw.trim().replace(/^0x/i, '') : '';
+  var eol = (eolKey && EOL_MAP[eolKey]) || 'unknown';
   if (!raw) return { life: 'unknown', wear: 'unknown', health: 'unknown', eol: eol };
 
   var parts = raw.split(/\s+/), wearList = [], minHealth = 100;

--- a/server/tvweb.js
+++ b/server/tvweb.js
@@ -3265,7 +3265,7 @@ function setupHomeAssistant() {
         type: 'sensor', id: 'gpu_clock',
         payload: {
           name: 'GPU Clock', state_topic: telemetryTopic,
-          value_template: '{{ value_json.gpuMhz }}',
+          value_template: '{{ value_json.gpuMhz if value_json.gpuMhz else none }}',
           unit_of_measurement: 'MHz', state_class: 'measurement', icon: 'mdi:expansion-card'
         }
       },


### PR DESCRIPTION
webOS 9+ returns `pre_eol_info` as `0x01` instead of `01`, so the EOL_MAP lookup missed and showed "unknown". Strips the `0x` prefix before matching.

Fixes macOS `tr: Illegal byte sequence` in the telnet deploy path by setting `LC_ALL=C`.

Adds OLED42C24LA (C2, webOS 9.2.2, firmware 23.25.55) to the testing table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)