### PR TITLE
Stop the privacy panel reporting services it started itself

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,8 @@ Store or one that does not.
   content recognition is actually running and sampling frames, your advertising
   identifier and whether ad tracking is limited, every data-collection
   agreement recorded on the TV, and which of LG's collection
-  services are alive. The agreements can be switched off from the panel and the
+  services are alive &mdash; the two the service bus starts on demand are marked
+  as such, and the two upstart supervises can be switched off for good. The agreements can be switched off from the panel and the
   change survives a reboot; acceptance of the terms themselves is left to the
   TV's own menus. Includes buttons to reset the advertising ID, clear ad
   cookies, and toggle the on-TV ad blocker. Deep link: `/?privacy=1`.

--- a/server/50-tvweb.sh
+++ b/server/50-tvweb.sh
@@ -14,6 +14,9 @@
 
 export PATH=/bin:/sbin:/usr/bin:/usr/sbin:$PATH
 
+# Hold down the LG daemons switched off in the dashboard. Done in the delayed
+# block below, after upstart has had its go at starting them.
+
 # Restore adblock bind-mount if enabled
 if [ -f /var/lib/tvweb/adblock_enabled ] && [ -f /var/lib/tvweb/adblock_hosts ]; then
   mount --bind /var/lib/tvweb/adblock_hosts /etc/hosts 2>/dev/null || true
@@ -26,6 +29,12 @@ fi
   sleep 20   # let the TV finish booting before adding load
   /usr/bin/pkill -9 -f tvweb.js 2>/dev/null || true
   sleep 1
+  if [ -f /var/lib/tvweb/services_stopped ]; then
+    while read -r job; do
+      [ -n "$job" ] && /sbin/initctl stop "$job" >/dev/null 2>&1
+    done < /var/lib/tvweb/services_stopped
+  fi
+
   if [ -x /var/lib/tvweb/tvwebctl ]; then
     /var/lib/tvweb/tvwebctl start
   else

--- a/server/assets/ui.html
+++ b/server/assets/ui.html
@@ -739,8 +739,8 @@ footer{margin-top:38px;font-size:12px;letter-spacing:.10em;text-transform:upperc
   <div id="pv-lmt"></div>
   <div class="sub" id="pv-adnote" style="margin-top:8px"></div>
   <div class="btns" style="margin-top:14px;max-width:520px">
-    <button onclick="privAction('resetAdId')">Reset advertising ID</button>
-    <button onclick="privAction('clearAdCookies')">Clear ad cookies</button>
+    <button id="adid-reset" onclick="privAction('resetAdId')">Reset advertising ID</button>
+    <button id="adcookies-clear" onclick="privAction('clearAdCookies')">Clear ad cookies</button>
   </div>
 
   <details class="pv-d">
@@ -755,7 +755,9 @@ footer{margin-top:38px;font-size:12px;letter-spacing:.10em;text-transform:upperc
   <summary>Background services <span class="cur" id="pv-daemons-cur"></span></summary>
   <div class="pv-sub">Whether LG's data-collection services are currently running. A
     service can be running while its permission is switched off &mdash; it simply has
-    nothing it is allowed to send.</div>
+    nothing it is allowed to send. The two marked <b>on demand</b> are started by the
+    service bus whenever anything asks them a question, so their running state is not a
+    choice the TV made. The other two are supervised jobs and can be held down.</div>
   <div id="pv-daemons"></div>
   </details>
 
@@ -1610,14 +1612,25 @@ async function loadPrivacy() {
     /* "Assigned" set in the heading face read as a section title rather than
        the state of the ID. It is a reading like any other in this panel, so it
        gets a row and a pill. */
+    // available === false means the call does not exist on this firmware, which
+    // is not the same answer as "no identifier assigned".
+    const adOk = ad.available !== false;
     q('pv-adid').innerHTML = pvRow('Advertising ID',
-      ad.present ? 'The value is deliberately not displayed here.'
-                 : 'No identifier is currently assigned.',
-      `<span class="pill ${ad.present ? 'warn' : 'good'}">${ad.present ? 'Assigned' : 'None'}</span>`);
+      !adOk ? 'This firmware does not answer the call that reads it.'
+            : ad.present ? 'The value is deliberately not displayed here.'
+                         : 'No identifier is currently assigned.',
+      !adOk ? '<span class="pill idle">Not readable</span>'
+            : `<span class="pill ${ad.present ? 'warn' : 'good'}">${ad.present ? 'Assigned' : 'None'}</span>`);
     q('pv-lmt').innerHTML = pvRow(
       ad.limitTrackingLabel || 'Limit ad tracking',
-      ad.limitTrackingDetail || '',
-      `<span class="pill ${ad.limitTracking ? 'good' : 'warn'}">${ad.limitTracking ? 'On' : 'Off'}</span>`);
+      adOk ? (ad.limitTrackingDetail || '') : 'Read from the same call, so it is unknown here.',
+      !adOk ? '<span class="pill idle">Unknown</span>'
+            : `<span class="pill ${ad.limitTracking ? 'good' : 'warn'}">${ad.limitTracking ? 'On' : 'Off'}</span>`);
+    // The two ad actions go through the same service, so they cannot work either.
+    for (const id of ['adid-reset', 'adcookies-clear']) {
+      const btn = q(id);
+      if (btn) btn.disabled = !adOk;
+    }
 
     // consent flags
     const c = d.consent || { known: [], other: [] };
@@ -1659,10 +1672,21 @@ async function loadPrivacy() {
       ? onCount + ' of ' + allConsent.length + ' on' : '';
 
     // services
-    q('pv-daemons').innerHTML = (d.daemons || []).map(x => pvRow(
-      x.label, x.detail,
-      `<span class="pill ${x.running ? 'idle' : 'good'}">${x.running ? 'Running' : 'Stopped'}</span>`)).join('');
     const dae = d.daemons || [];
+    q('pv-daemons').innerHTML = dae.map(x => {
+      const state = x.running ? 'Running' : 'Stopped';
+      const cls = x.running ? 'idle' : 'good';
+      if (x.onDemand) {
+        return pvRow(esc(x.label), esc(x.detail) +
+          ' <span class="k">&middot; on demand, so asking it anything starts it</span>',
+          `<span class="pill idle fixed">${state}</span>`);
+      }
+      const note = x.heldDown ? ' <span class="k">&middot; kept stopped at boot</span>' : '';
+      const pill = (x.stoppable && cw)
+        ? `<button class="pill ${cls}" data-svc="${esc(x.name)}" data-next="${x.running ? '0' : '1'}">${state}</button>`
+        : `<span class="pill ${cls}">${state}</span>`;
+      return pvRow(esc(x.label), esc(x.detail) + note, pill);
+    }).join('');
     q('pv-daemons-cur').textContent = dae.length
       ? dae.filter(x => x.running).length + ' of ' + dae.length + ' running' : '';
 
@@ -1705,6 +1729,15 @@ q('pv-consent').addEventListener('click', async (ev) => {
   btn.textContent = '...';
   const r = await c('consent', { key: btn.dataset.key, enabled: btn.dataset.next === '1' });
   if (!r || !r.ok) { btn.disabled = false; loadPrivacy(); return; }
+  loadPrivacy();
+});
+
+q('pv-daemons').addEventListener('click', async (ev) => {
+  const btn = ev.target.closest('button.pill[data-svc]');
+  if (!btn) return;
+  btn.disabled = true;
+  btn.textContent = '...';
+  await c('service', { name: btn.dataset.svc, enabled: btn.dataset.next === '1' });
   loadPrivacy();
 });
 

--- a/server/tvweb.js
+++ b/server/tvweb.js
@@ -1960,13 +1960,79 @@ var CONSENT_NAMES = {
   allAllowed:          'Select All'
 };
 
-// Daemons worth naming, with what they actually do.
+/*
+ * Daemons worth naming, with what they do and how the platform runs them.
+ *
+ * "bus" ones are started on demand by ls-hubd: asking them anything starts
+ * them, this panel's own getAdid call included, so whether the process exists
+ * says nothing about whether the TV chose to run it. "upstart" ones are
+ * supervised jobs whose running state is real, and which initctl can hold down.
+ */
 var PRIVACY_DAEMONS = {
-  acr2:       ['Content recognition service', 'Identifies what is on screen'],
-  admanager:  ['Advertising service', 'Fetches and displays ads on the TV'],
-  uploadd:    ['Diagnostics uploader', 'Sends diagnostic data to LG'],
-  rdxd:       ['Diagnostics collector', 'Gathers crash and diagnostic reports']
+  acr2:       ['Content recognition service', 'Identifies what is on screen', 'bus'],
+  admanager:  ['Advertising service', 'Fetches and displays ads on the TV', 'bus'],
+  uploadd:    ['Diagnostics uploader', 'Sends diagnostic data to LG', 'upstart'],
+  rdxd:       ['Diagnostics collector', 'Gathers crash and diagnostic reports', 'upstart']
 };
+
+/*
+ * Held down across reboots by the boot hook, which reads this file. Only jobs
+ * upstart supervises can be held down at all - the bus starts the others back
+ * up the moment anything asks them a question.
+ */
+var SERVICES_FILE = '/var/lib/tvweb/services_stopped';
+var SERVICE_CONTROLLABLE = { uploadd: true, rdxd: true };
+
+function stoppedServices() {
+  var raw = rd(SERVICES_FILE), out = [];
+  if (!raw) return out;
+  var parts = raw.split('\n');
+  for (var i = 0; i < parts.length; i++) {
+    var n = parts[i].replace(/\s+/g, '');
+    if (n && SERVICE_CONTROLLABLE[n] && out.indexOf(n) === -1) out.push(n);
+  }
+  return out;
+}
+
+/*
+ * Upstart's view, or nothing. webOS 9 keeps an initctl that lists no jobs at
+ * all - on a C2 it answers `touch: /tmp/rdxd: Read-only file system` - so the
+ * set gets no toggles there, which is the right answer: uploadd and rdxd run,
+ * but not as jobs anything here can hold down.
+ */
+function upstartJobs(cb) {
+  execFile('/sbin/initctl', ['list'], { timeout: 4000 }, function (err, stdout) {
+    var out = {}, lines = String(stdout || '').split('\n');
+    for (var i = 0; i < lines.length; i++) {
+      var m = /^(\S+)\s+(\S+)/.exec(lines[i]);
+      if (m) out[m[1]] = m[2].replace(/,$/, '');   // "start/running, process 123"
+    }
+    cb(out);
+  });
+}
+
+function setServiceEnabled(name, enable, cb) {
+  execFile('/sbin/initctl', [enable ? 'start' : 'stop', name], { timeout: 6000 }, function () {
+    // initctl reports failure when the job is already in the state asked for,
+    // so the job's own state decides, not the exit code.
+    upstartJobs(function (jobs) {
+      var running = String(jobs[name] || '').indexOf('start/') === 0;
+      var list = stoppedServices(), at = list.indexOf(name);
+      if (enable && at !== -1) list.splice(at, 1);
+      if (!enable && at === -1) list.push(name);
+      try {
+        if (list.length) fs.writeFileSync(SERVICES_FILE, list.join('\n') + '\n', 'utf8');
+        else if (fs.existsSync(SERVICES_FILE)) fs.unlinkSync(SERVICES_FILE);
+      } catch (e) { /* the job moved either way; only the boot hook loses out */ }
+      cachedPrivacy = null;
+      console.log('service: ' + name + ' -> ' + (enable ? 'start' : 'stop') +
+                  (running === enable ? '' : ' (did not take)'));
+      cb(running === enable
+        ? { ok: true, name: name, running: running }
+        : { ok: false, error: 'the TV did not ' + (enable ? 'start' : 'stop') + ' ' + name });
+    });
+  });
+}
 
 /*
  * Power state. tvpower reports the panel separately from the system: a set can
@@ -2047,18 +2113,27 @@ function readConsentFlags() {
 }
 
 function runningDaemons(cb) {
-  execFile('/bin/ps', ['-eo', 'args'], { timeout: 4000 }, function (err, stdout) {
-    var txt = String(stdout || ''), list = [];
-    for (var name in PRIVACY_DAEMONS) {
-      if (!PRIVACY_DAEMONS.hasOwnProperty(name)) continue;
-      list.push({
-        name: name,
-        label: PRIVACY_DAEMONS[name][0],
-        detail: PRIVACY_DAEMONS[name][1],
-        running: txt.indexOf('/usr/sbin/' + name) !== -1
-      });
-    }
-    cb(list);
+  var held = stoppedServices();
+  upstartJobs(function (jobs) {
+    execFile('/bin/ps', ['-eo', 'args'], { timeout: 4000 }, function (err, stdout) {
+      var txt = String(stdout || ''), list = [];
+      for (var name in PRIVACY_DAEMONS) {
+        if (!PRIVACY_DAEMONS.hasOwnProperty(name)) continue;
+        var d = PRIVACY_DAEMONS[name];
+        var onDemand = d[2] === 'bus';
+        list.push({
+          name: name,
+          label: d[0],
+          detail: d[1],
+          running: txt.indexOf('/usr/sbin/' + name) !== -1,
+          onDemand: onDemand,
+          job: jobs[name] || null,
+          stoppable: !onDemand && !!SERVICE_CONTROLLABLE[name] && !!jobs[name],
+          heldDown: held.indexOf(name) !== -1
+        });
+      }
+      cb(list);
+    });
   });
 }
 
@@ -2069,35 +2144,48 @@ function collectPrivacy(cb) {
   var out = { ok: true, consent: readConsentFlags(), consentWritable: CONFIG.allowControl,
               consentGroups: CONSENT_GROUPS };
 
-  luna('com.webos.service.acr/getACRSolutionStatus', {}, function (acr) {
-    // `false` here means the recognition engine is not running at all.
-    out.acr = {
-      label: 'Screen content recognition',
-      detail: 'LG calls this ACR. It samples what is on screen to work out what you are watching.',
-      active: !!(acr && acr.ACRSolutionStatus)
-    };
-    luna('com.webos.service.acr/getVideoCaptureStatus', {}, function (cap) {
-      out.acr.capturing = !!(cap && cap.status && cap.status !== 'stopped');
-      out.acr.captureState = (cap && cap.status) ? cap.status : 'unknown';
-      luna('com.webos.service.admanager/getAdid', {}, function (ad) {
-        var id = (ad && ad.IFA) ? String(ad.IFA) : null;
-        out.advertisingId = {
-          label: 'Advertising identifier',
-          detail: 'A unique ID your TV hands to advertisers. Resetting it breaks the link to your past activity.',
+  /*
+   * Scan first. Every luna call below starts the service it asks, so a scan
+   * afterwards can only ever report acr2 and admanager as running - which is
+   * what this panel did, on every load, for as long as it has existed.
+   */
+  runningDaemons(function (daemons) {
+    out.daemons = daemons;
+    luna('com.webos.service.acr/getACRSolutionStatus', {}, function (acr) {
+      // `false` here means the recognition engine is not running at all.
+      out.acr = {
+        label: 'Screen content recognition',
+        detail: 'LG calls this ACR. It samples what is on screen to work out what you are watching.',
+        active: !!(acr && acr.ACRSolutionStatus)
+      };
+      luna('com.webos.service.acr/getVideoCaptureStatus', {}, function (cap) {
+        out.acr.capturing = !!(cap && cap.status && cap.status !== 'stopped');
+        out.acr.captureState = (cap && cap.status) ? cap.status : 'unknown';
+        luna('com.webos.service.admanager/getAdid', {}, function (ad) {
           /*
-           * The value is deliberately NOT returned, not even truncated. It is
-           * an identifier for this household, and the dashboard is the sort of
-           * thing that ends up in screenshots. Whether a reset worked is
-           * reported by the reset action itself, which compares before and
-           * after on the TV without either value leaving it.
+           * getAdid does not exist on every firmware - a C8 on 4.4.0 answers
+           * `Unknown method`, a B8 on 4.4.3 answers properly. Without this the
+           * failure renders as "no identifier assigned", which is a claim about
+           * the TV rather than about the call.
            */
-          present: !!id,
-          limitTracking: !!(ad && String(ad.LMT).toLowerCase() === 'on'),
-          limitTrackingLabel: 'Limit ad tracking',
-          limitTrackingDetail: 'When on, apps are asked not to use this ID to profile you.'
-        };
-        runningDaemons(function (daemons) {
-          out.daemons = daemons;
+          var adOk = !!(ad && ad.returnValue !== false && ad.IFA !== undefined);
+          var id = (adOk && ad.IFA) ? String(ad.IFA) : null;
+          out.advertisingId = {
+            available: adOk,
+            label: 'Advertising identifier',
+            detail: 'A unique ID your TV hands to advertisers. Resetting it breaks the link to your past activity.',
+            /*
+             * The value is deliberately NOT returned, not even truncated. It is
+             * an identifier for this household, and the dashboard is the sort of
+             * thing that ends up in screenshots. Whether a reset worked is
+             * reported by the reset action itself, which compares before and
+             * after on the TV without either value leaving it.
+             */
+            present: !!id,
+            limitTracking: !!(ad && String(ad.LMT).toLowerCase() === 'on'),
+            limitTrackingLabel: 'Limit ad tracking',
+            limitTrackingDetail: 'When on, apps are asked not to use this ID to profile you.'
+          };
           out.adblock = {
             enabled: isAdBlockActive(),
             mode: adBlockMode(),
@@ -2334,6 +2422,19 @@ function doControl(action, value, cb) {
           });
         });
       });
+
+    /*
+     * Hold an LG daemon down, or let it back up. Restricted to the two upstart
+     * supervises: this is an initctl target arriving over HTTP, and the
+     * bus-activated services cannot be held down anyway.
+     */
+    case 'service':
+      var svcName = (value && value.name) ? String(value.name) : '';
+      var svcOn = !!(value && (value.enabled === true || value.enabled === 'true'));
+      if (!SERVICE_CONTROLLABLE[svcName]) {
+        return cb({ ok: false, error: svcName ? svcName + ' is not controllable' : 'no service named' });
+      }
+      return setServiceEnabled(svcName, svcOn, cb);
 
     case 'clearAdCookies':
       return luna('com.webos.service.admanager/inactivateCookies', {}, function (r) {


### PR DESCRIPTION
Three things reported in #61, all reproduced on a B8.

**The panel woke the services it then reported.** `collectPrivacy` asked acr2
and admanager questions and scanned `ps` afterwards, so both were always
running by the time it looked — the panel has said "4 of 4 running" for as long
as it has existed. Proved by killing admanager: it stays dead for as long as
nothing asks it anything, and one `getAdid` brings it back, with upstart
reporting `stop/waiting` throughout.

The scan now runs first, and the two the service bus starts on demand are
labelled instead of being given a running state that was never the TV's choice.

**`getAdid` does not exist on every firmware.** A C8 on 4.4.0 answers
`Unknown method`; a B8 on 4.4.3 answers properly. The failure rendered as "no
identifier assigned" — a claim about the TV rather than about the call. It now
reports that the firmware cannot answer, and disables the two actions that go
through the same service.

**uploadd and rdxd can be switched off**, and stay off across reboots via the
boot hook, the same mechanism the sinkhole already uses. Only those two: they
are what upstart supervises, and the bus restarts acr2 and admanager on the
next question anyone asks. The service name is whitelisted — this is an
initctl target arriving over HTTP. A TV whose initctl lists no jobs gets no
toggles, which is what a C2 on webOS 9.2.2 does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)