### PR TITLE
Detect the blocker by what is in /etc/hosts, not by what is mounted

### DIFF
--- a/server/tvweb.js
+++ b/server/tvweb.js
@@ -848,6 +848,13 @@ function refreshInstalledApps(cb) {
 }
 
 var ADBLOCK_HOSTS_FILE = '/var/lib/tvweb/adblock_hosts';
+/*
+ * Written into the table and looked for in the live /etc/hosts. Asking
+ * /proc/mounts whether anything is mounted there answers a different question:
+ * webosbrew bind-mounts that path itself on some installs, and this then
+ * reported the blocker as on while none of these domains were in effect.
+ */
+var ADBLOCK_MARKER = '# LG Ad & Telemetry Blackhole (lg-webos-mqtt)';
 var ADBLOCK_FLAG_FILE = '/var/lib/tvweb/adblock_enabled';
 /* Ad, tracking and telemetry hosts. Nothing on the TV needs to reach them. */
 var ADBLOCK_ADS = [
@@ -928,8 +935,8 @@ function isAdBlockActive() {
     return cachedAdBlockActive;
   }
   try {
-    var mounts = fs.readFileSync('/proc/mounts', 'utf8');
-    cachedAdBlockActive = mounts.indexOf(' /etc/hosts ') !== -1;
+    var hosts = fs.readFileSync('/etc/hosts', 'utf8');
+    cachedAdBlockActive = hosts.indexOf(ADBLOCK_MARKER) !== -1;
     lastAdBlockCheck = now;
     return cachedAdBlockActive;
   } catch (e) {
@@ -949,7 +956,7 @@ function setAdBlock(mode, cb) {
       'ff02::1\tip6-allnodes',
       'ff02::2\tip6-allrouters',
       '',
-      '# LG Ad & Telemetry Blackhole (lg-webos-mqtt)'
+      ADBLOCK_MARKER
     ];
     for (var i = 0; i < list.length; i++) {
       lines.push('0.0.0.0\t' + list[i]);
@@ -968,7 +975,12 @@ function setAdBlock(mode, cb) {
       if (cb) cb({ ok: false, error: 'could not write adblock hosts: ' + e.message });
       return;
     }
-    if (active) {   // already mounted: the rewrite above is the whole change
+    /*
+     * Our table is already the live one, so rewriting it in place is the whole
+     * change and the tier switches without a remount. Anything else mounted
+     * there belongs to someone else, and a bind mount stacks on top of it.
+     */
+    if (active) {
       cachedAdBlockActive = null;
       cachedPrivacy = null;
       lastStats = null;


### PR DESCRIPTION
`isAdBlockActive()` asked `/proc/mounts` whether *anything* was mounted over
`/etc/hosts`. That answers a different question from "is our blocklist in
effect".

On installs where webosbrew bind-mounts that path for its own purposes, the
blocker reported as on while none of its domains were live: `setAdBlock()`
wrote its table, saw a mount it assumed was its own, and returned success. The
tier-switch optimisation made it worse, since "already mounted, so rewriting in
place is the whole change" only holds when the mount is ours.

Reported on r/homeassistant against a 55UH6030 on webOS 3.4.3. Neither test set
hits it, which is why it survived five releases.

The check now looks for our own marker line in the live `/etc/hosts`. A foreign
mount reads as off, and enabling stacks a bind mount on top of it.

Reproduced on a B8 by bind-mounting a foreign file over `/etc/hosts` first:

| Step | Result |
| :--- | :--- |
| foreign file mounted | panel reports **off** (before: on) |
| enable *ads* | 2 mounts, our marker live, `ad.lgsmartad.com → 0.0.0.0` |
| switch to *everything* | still 2 mounts, 9 → 19 hosts, rewritten in place |
| switch off | back to 1 mount, the foreign file intact and ours gone |

Unmounting reveals what was underneath rather than leaving `/etc/hosts`
missing, so a TV that had its own mount keeps it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)