### PR TITLE
Add a D-pad to the controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ and firmware updates use.
 
 ## What it's for
 
-1. **Controlling the TV without the cloud.** Volume, mute, media playback keys (play, pause, stop, skip), app launcher, picture presets, sound output routing, power and reboot.
+1. **Controlling the TV without the cloud.** A D-pad to navigate the TV itself, volume, mute, media playback keys (play, pause, stop, skip), app launcher, picture presets, sound output routing, power and reboot.
 
 2. **Seeing what the TV collects, and switching it off.** Whether LG's
    content-recognition engine is running and sampling your screen, your
@@ -130,7 +130,7 @@ and firmware updates use.
 * **Advanced panels.** HDMI link state per port straight off the receiver
   (resolution, refresh rate, colour depth, pixel clock) and a read-only list of
   what is resident in memory. Both load on demand.
-* **Bi-directional control.** Volume, mute, input select, media playback (play/pause/stop/skip via native remote key injection), app launching, picture presets, sound outputs, screen blanking, sleep timer, standby LED, on-screen notifications, power and restart (from the dashboard or Home Assistant). The picture presets on offer are the ones the TV will accept for whatever is playing &mdash; a Dolby Vision source has its own set.
+* **Bi-directional control.** A D-pad - arrows, OK, Back and Home - to drive the TV's own interface from a browser, volume, mute, input select, media playback (play/pause/stop/skip via native remote key injection), app launching, picture presets, sound outputs, screen blanking, sleep timer, standby LED, on-screen notifications, power and restart (from the dashboard or Home Assistant). The picture presets on offer are the ones the TV will accept for whatever is playing &mdash; a Dolby Vision source has its own set.
 * **Ad & telemetry blocker.** Blackholes LG's tracking, ad and ACR
   endpoints on the set itself by bind-mounting a hosts table over `/etc/hosts`.
   Automatically restored on boot. Two tiers: *ads & telemetry* blocks the nine

--- a/server/assets/ui.html
+++ b/server/assets/ui.html
@@ -308,6 +308,18 @@ button[disabled]:hover{color:var(--w60);border-color:var(--w12)}
    what someone hovering it wants. */
 button.btn-off{opacity:.28;cursor:not-allowed}
 button.btn-off:hover{color:var(--w60);border-color:var(--w12);background:transparent}
+.dpad{display:grid;grid-template-columns:repeat(3,1fr);grid-template-rows:repeat(3,auto);
+      gap:8px;max-width:260px;margin:0 auto 14px}
+/* The arrows are glyphs, not words: the button voice everywhere else is
+   uppercase and letter-spaced, which pushes a single glyph off centre. */
+.dpad .dp{min-height:0;height:62px;padding:0;font-size:15px;letter-spacing:0;
+          text-transform:none;display:flex;align-items:center;justify-content:center}
+.dpad .dp-ok{font-size:12px;letter-spacing:.1em}
+.dp-up{grid-column:2;grid-row:1}
+.dp-left{grid-column:1;grid-row:2}
+.dp-ok{grid-column:2;grid-row:2}
+.dp-right{grid-column:3;grid-row:2}
+.dp-down{grid-column:2;grid-row:3}
 
 
 /* ---- privacy pane ---- */
@@ -735,6 +747,26 @@ footer{margin-top:38px;font-size:12px;letter-spacing:.10em;text-transform:upperc
         <button onclick="c('media','fastForward')">Fast Fwd</button>
       </div>
     </div>
+
+    <!-- Pinned to the first column: it is the one control here that people
+         reach for repeatedly, so it should not move about as the others grow. -->
+    <details class="disc" id="disc-dpad" data-col="0">
+      <summary>D-pad <span class="cur">Navigate the TV</span></summary>
+
+      <div class="set">
+        <div class="dpad">
+          <button class="dp dp-up"    onclick="c('rcu','up')"    title="Up">&#9650;</button>
+          <button class="dp dp-left"  onclick="c('rcu','left')"  title="Left">&#9664;</button>
+          <button class="dp dp-ok"    onclick="c('rcu','ok')"    title="Select">OK</button>
+          <button class="dp dp-right" onclick="c('rcu','right')" title="Right">&#9654;</button>
+          <button class="dp dp-down"  onclick="c('rcu','down')"  title="Down">&#9660;</button>
+        </div>
+        <div class="btns">
+          <button onclick="c('rcu','back')">Back</button>
+          <button onclick="c('rcu','home')">Home</button>
+        </div>
+      </div>
+    </details>
 
     <details class="disc" id="disc-timers">
       <summary>Sleep timer <span class="cur" id="tl-cur"></span></summary>

--- a/server/tvweb.js
+++ b/server/tvweb.js
@@ -2703,6 +2703,27 @@ function detectLogoLight(cb) {
     });
 }
 
+/*
+ * Remote navigation. Sent through the network input service rather than written
+ * to /dev/input: it is a service call, and the TV accepts it whatever is in the
+ * foreground.
+ *
+ * Arrows and enter are the standard evdev codes. Back is LG's own - 412, the
+ * IR_KEY_BACK in /usr/share/X11/xkb/keycodes/lg less the 8 that xkb adds - and
+ * measured on a C2 it is the one that acts; evdev's 158 is taken as a dismissal
+ * rather than a step back. The service refuses anything above about 512, which
+ * rules out the rest of LG's table, and no code was found for Home at all, so
+ * that launches the home app instead.
+ */
+var RCU_KEYS = {
+  up: 103,
+  down: 108,
+  left: 105,
+  right: 106,
+  ok: 28,
+  back: 412
+};
+
 var SLEEP_TIMER_VALUES = ['off', '10', '30', '60', '90', '120'];
 
 // What the settings service accepts for logoLuminanceAdjust, per
@@ -2937,6 +2958,21 @@ function doControl(action, value, cb) {
       var lightPayload = { category: 'option', settings: {} };
       lightPayload.settings[lightKey] = lightOn ? 'on' : 'off';
       return luna('com.webos.service.settings/setSystemSettings', lightPayload,
+                  function (r) { lastStats = null; cb({ ok: !!(r && r.returnValue) }); });
+
+    case 'rcu':
+      var rcuName = String(value || '').trim().toLowerCase();
+      if (rcuName === 'home') {
+        // No keycode reaches the home screen - the service rejects LG's own -
+        // so ask the application manager for it directly.
+        return luna('com.webos.applicationManager/launch', { id: 'com.webos.app.home' },
+                    function (r) { lastStats = null; cb({ ok: !!(r && r.returnValue) }); });
+      }
+      if (!RCU_KEYS.hasOwnProperty(rcuName)) {
+        return cb({ ok: false, error: 'unknown key: ' + rcuName });
+      }
+      return luna('com.webos.service.networkinput/test/sendKeyCode',
+                  { keyCode: RCU_KEYS[rcuName] },
                   function (r) { lastStats = null; cb({ ok: !!(r && r.returnValue) }); });
 
     case 'screensaverMode':


### PR DESCRIPTION
Arrows, OK, Back and Home, in an expanding section pinned to the first column
of the Control tab - it is the one control here people reach for repeatedly, so
it should not move about as the others grow.

Keys go through `com.webos.service.networkinput/test/sendKeyCode` rather than
writing to `/dev/input`: it is a service call, and the TV takes it whatever is
in the foreground.

Three findings worth recording. Arrows and enter are the standard evdev codes.
Back is LG's own **412** - the `IR_KEY_BACK` in
`/usr/share/X11/xkb/keycodes/lg` less the 8 that xkb adds - and that is the one
that acts; evdev's 158 reads as a dismissal rather than a step back. And the
service refuses anything above about 512, which rules out the rest of LG's
table: no keycode reaches the home screen at all, so Home launches the home app
instead.

Verified on a C2 by capturing the compositor either side of each press: left
and right move 10% of the screen, up and down 1%, OK 99% (it opened an app),
Back 57%, while 172, 174 and 773 move none of it. The buttons were then clicked
in a browser with the command stubbed, confirming all seven are wired to the
right key and that the section lands in the first column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)